### PR TITLE
make nginx accept any hostname

### DIFF
--- a/nginx/etc/nginx/conf.d/project.conf
+++ b/nginx/etc/nginx/conf.d/project.conf
@@ -1,6 +1,6 @@
 server {
-  listen       80;
-  server_name  $hostname $hostname.local $hostname.$domain;
+  listen       80 default_server;
+  server_name  _;
   root /app/www/active;
 
   error_log /app/log/nginx/project.error_log;


### PR DESCRIPTION
I had some issues with the nginx configuration, which was tied to a strict set of URIs.

This patch makes nginx much more lenient, accepting any incoming http connections.
