### PR TITLE
Some changes to PHP ini across the 5.6 implementations

### DIFF
--- a/lampstackplus/etc/php.ini
+++ b/lampstackplus/etc/php.ini
@@ -660,7 +660,7 @@ auto_globals_jit = On
 ; Its value may be 0 to disable the limit. It is ignored if POST data reading
 ; is disabled through enable_post_data_reading.
 ; http://php.net/post-max-size
-post_max_size = 8M
+post_max_size = 128M
 
 ; Automatically add files before PHP document.
 ; http://php.net/auto-prepend-file
@@ -703,6 +703,7 @@ default_charset = "UTF-8"
 ; $HTTP_RAW_POST_DATA is *NOT* populated.
 ; http://php.net/always-populate-raw-post-data
 ;always_populate_raw_post_data = -1
+always_populate_raw_post_data = -1
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;
 ; Paths and Directories ;

--- a/lampstackplus/etc/php.ini
+++ b/lampstackplus/etc/php.ini
@@ -892,6 +892,7 @@ cli_server.color = On
 ; Defines the default timezone used by the date functions
 ; http://php.net/date.timezone
 ;date.timezone =
+date.timezone = "UTC"
 
 ; http://php.net/date.default-latitude
 ;date.default_latitude = 31.7667

--- a/php56fpm/etc/php.ini
+++ b/php56fpm/etc/php.ini
@@ -660,7 +660,7 @@ auto_globals_jit = On
 ; Its value may be 0 to disable the limit. It is ignored if POST data reading
 ; is disabled through enable_post_data_reading.
 ; http://php.net/post-max-size
-post_max_size = 8M
+post_max_size = 128M
 
 ; Automatically add files before PHP document.
 ; http://php.net/auto-prepend-file
@@ -703,6 +703,7 @@ default_charset = "UTF-8"
 ; $HTTP_RAW_POST_DATA is *NOT* populated.
 ; http://php.net/always-populate-raw-post-data
 ;always_populate_raw_post_data = -1
+always_populate_raw_post_data = -1
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;
 ; Paths and Directories ;

--- a/php56fpm/etc/php.ini
+++ b/php56fpm/etc/php.ini
@@ -892,6 +892,7 @@ cli_server.color = On
 ; Defines the default timezone used by the date functions
 ; http://php.net/date.timezone
 ;date.timezone =
+date.timezone = "UTC"
 
 ; http://php.net/date.default-latitude
 ;date.default_latitude = 31.7667


### PR DESCRIPTION
Changes:
- increate php56 POST size limit; 
- disable always_populate_raw_post_data.

Applied to:
- php56fpm
- lampstackplus
