### PR TITLE
Updated lampstack to convert tcp sockets to unix sockets.

### DIFF
--- a/lampstackplus/Dockerfile
+++ b/lampstackplus/Dockerfile
@@ -22,18 +22,20 @@ RUN /usr/bin/mysql_install_db --basedir=/usr --datadir=/var/lib/mysql --user=mys
 
 # Initial db setup
 # - Secure the db, leaving a lame root password, that can be changed in sub images, or in containers
+#      (now leaving the root password as blank)
 # - Kill the anonymous users
 # - Kill off the demo database
-# - Add our custom project DB
-# - Grant needed privileges on our needed project DB
+# - Add our custom app DB
+# - Grant needed privileges on our needed app DB
 # - Make our changes take effect
 RUN (/usr/bin/mysqld_safe &) && sleep 5 && \
-   mysql -uroot -e "UPDATE mysql.user SET Password=PASSWORD('RESETME') WHERE User='root'" && \
    mysql -uroot -e "DELETE FROM mysql.user WHERE User=''" && \
    mysql -uroot -e "DROP DATABASE test" && \
-   mysql -uroot -e "CREATE DATABASE project" && \
-   mysql -uroot -e "GRANT ALL on project.* to project IDENTIFIED BY \"project\"" && \
+   mysql -uroot -e "CREATE DATABASE app" && \
+   mysql -uroot -e "GRANT ALL on app.* to app IDENTIFIED BY \"app\"" && \
    mysql -uroot -e "FLUSH PRIVILEGES"
+
+# REMOVE ROOT PASSWORD: mysql -uroot -e "UPDATE mysql.user SET Password=PASSWORD('RESETME') WHERE User='root'"
 
 # AS a command, run the mariadb server, and expose the 3306 port for TCP connections
 #ENTRYPOINT ["/usr/bin/mysqld_safe"]
@@ -81,7 +83,7 @@ ADD etc/yum.repos.d/remi.repo /etc/yum.repos.d/remi.repo
 # Install php-fpm
 RUN /usr/bin/yum install --assumeyes --verbose \
     php-fpm php-opcache php-pecl-apc php-pdo php-mysql php-pgsql php-pecl-mongo \
-    php-ldap php-sqlite php-pecl-memcache php-pecl-memcached php-gd php-mbstring \
+    php-ldap php-sqlite php-pecl-memcache php-pecl-memcached memcached php-gd php-mbstring \
     php-mcrypt php-xml php-pecl-yaml php-twig php-twig-ctwig php-pecl-uploadprogress
 
 # make sure that the nginx user, created, has access to app user files
@@ -91,8 +93,11 @@ RUN /usr/bin/mkdir -p /app/log/php-fpm && \
 
 # Override some of the default php-fpm settings with our own.
 ADD etc/php.ini /etc/php.ini
-ADD etc/php-fpm.d/www.conf /etc/php-fpm.d/www.conf
 ADD etc/php-fpm.conf /etc/php-fpm.conf
+ADD etc/php-fpm.d/www.conf /etc/php-fpm.d/www.conf
+
+# Add some php extension configuraiton overrides
+ADD etc/php.d/40-apcu.ini /etc/php.d/40-apcu.ini
 
 # Start the PHP-FPM service, and expose the 9000 port for TCP connections
 #ENTRYPOINT ["/usr/sbin/php-fpm"]
@@ -108,8 +113,8 @@ RUN /usr/bin/yum install -y install pygpgme blackfire-agent blackfire-php
 RUN /bin/mkdir -p /var/run/blackfire && \
     /bin/mkdir -p /var/log/blackfire
 
-# Enable the blackfire php agent
-RUN /usr/bin/sed -i "s,unix:///var/run/blackfire/agent.sock,tcp://blackfire.app:8707," /etc/php.d/zz-blackfire.ini
+# Enable the blackfire php agent php extension
+ADD etc/php.d/99-blackfire.ini /etc/php.d/99-blackfire.ini
 
 # These ENV vars can be used to configure the server
 ENV BLACKFIRE_SERVER_ID %BLACKFIRE_SERVER_ID

--- a/lampstackplus/etc/nginx/conf.d/default.conf
+++ b/lampstackplus/etc/nginx/conf.d/default.conf
@@ -3,8 +3,8 @@ server {
   server_name  _;
   root /app/www;
 
-  error_log /app/log/nginx/error_log;
-  access_log /app/log/nginx/access_log;
+  error_log /app/log/nginx/error.log;
+  access_log /app/log/nginx/access.log;
 
   charset utf8;
 
@@ -52,7 +52,7 @@ server {
     include fastcgi_params;
     fastcgi_param SCRIPT_FILENAME $request_filename;
     fastcgi_intercept_errors on;
-    fastcgi_pass "localhost:9000";
+    fastcgi_pass "unix:/var/run/php-fpm.sock";
   }
 
   # Fighting with Styles? This little gem is amazing.

--- a/lampstackplus/etc/php-fpm.d/www.conf
+++ b/lampstackplus/etc/php-fpm.d/www.conf
@@ -9,7 +9,7 @@
 ;                            specific port;
 ;   '/path/to/unix/socket' - to listen on a unix socket.
 ; Note: This value is mandatory.
-listen = 0.0.0.0:9000
+listen = /var/run/php-fpm.sock
 
 ; Set listen(2) backlog. A value of '-1' means unlimited.
 ; Default Value: -1
@@ -28,8 +28,8 @@ listen = 0.0.0.0:9000
 ; BSD-derived systems allow connections regardless of permissions.
 ; Default Values: user and group are set as the running user
 ;                 mode is set to 0666
-;listen.owner = nobody
-;listen.group = nobody
+listen.owner = nginx
+listen.group = nginx`
 ;listen.mode = 0666
 
 ; Unix user/group of processes

--- a/lampstackplus/etc/php.d/40-apcu.ini
+++ b/lampstackplus/etc/php.d/40-apcu.ini
@@ -1,0 +1,73 @@
+; Enable APCu extension module
+extension = apcu.so
+
+;	This can be set to 0 to disable APCu
+apc.enabled=1
+
+;	Setting this enables APCu for the CLI version of PHP
+;	(Mostly for testing and debugging).
+;apc.enable_cli=0
+apc.enable_cli=1
+
+;	Sets the path to text files containing caches to load from disk upon
+;	initialization of APCu. preload_path should be a directory where each
+;	file follows $key.data where $key should be used as the entry name
+;	and the contents of the file contains serialized data to use as the value
+;	of the entry.
+;apc.preload_path=
+
+;	The size of each shared memory segment, with M/G suffixe
+;apc.shm_size=32M
+
+;	The number of seconds a cache entry is allowed to idle in a slot in case
+;	this cache entry slot is needed by another entry.
+;apc.ttl=0
+
+;	The number of seconds that a cache entry may remain on the
+;	garbage-collection list.
+;apc.gc_ttl=3600
+
+;	If you begin to get low on resources, an expunge of the cache
+;	is performed if it is less than half full. This is not always
+;	a suitable way of determining if an expunge of the cache
+;	should be per apc.smart allows you to set a runtime configuration
+;	value which	is used to determine if an expunge should be run
+;	if (available_size < apc.smart * requested_size)
+;apc.smart=0
+
+;	A "hint" about the number variables expected in the cache.
+;	Set to zero or omit if you are not sure;
+;apc.entries_hint=4096
+
+;	The mktemp-style file_mask to pass to the mmap module 
+apc.mmap_file_mask=/tmp/apc.XXXXXX
+
+;	On very busy servers whenever you start the server or
+;	modify files you can create a race of many processes
+;	all trying to cache the same data at the same time.
+;	By default, APCu attempts to prevent "slamming" of a key.
+;	A key is considered "slammed" if it was the last key set,
+;	and a context other than the current one set it ( ie. it
+;	was set by another process or thread )
+;apc.slam_defense=1
+
+;	Defines which serializer should be used
+;	Default is the standard PHP serializer.
+;apc.serializer='default'
+
+;	use the SAPI request start time for TTL
+;apc.use_request_time=1
+
+;	Enables APCu handling of signals, such as SIGSEGV, that write core files
+;	when signaled. APCu will attempt to unmap the shared memory segment in
+;	order to exclude it from the core file
+;apc.coredump_unmap=0
+
+
+;	RFC1867 File Upload Progress hook handler
+;apc.rfc1867=0
+;apc.rfc1867_prefix =upload_
+;apc.rfc1867_name=APC_UPLOAD_PROGRESS
+;apc.rfc1867_freq=0
+;apc.rfc1867_ttl=3600
+

--- a/lampstackplus/etc/php.d/99-blackfire.ini
+++ b/lampstackplus/etc/php.d/99-blackfire.ini
@@ -1,0 +1,9 @@
+; priority=90
+[blackfire]
+extension=blackfire.so
+blackfire.agent_socket = unix:///var/run/blackfire/agent.sock
+blackfire.agent_timeout = 0.25
+;blackfire.server_id =
+;blackfire.server_token =
+;blackfire.log_level = 3
+blackfire.log_file = /app/log/blackfire.log

--- a/lampstackplus/etc/php.ini
+++ b/lampstackplus/etc/php.ini
@@ -881,9 +881,6 @@ default_socket_timeout = 60
 ; Module Settings ;
 ;;;;;;;;;;;;;;;;;;;
 
-[apc]
-apc.rfc1867 = 1
-
 [CLI Server]
 ; Whether the CLI web server uses ANSI color coding in its terminal output.
 cli_server.color = On

--- a/lampstackplus/etc/supervisord.d/blackfire.ini
+++ b/lampstackplus/etc/supervisord.d/blackfire.ini
@@ -1,6 +1,6 @@
 
 [program:blackfire]
-command=blackfire-agent --socket tcp://0.0.0.0:8707 --config /dev/null
+command=blackfire-agent --socket unix:///var/run/blackfire/agent.sock --config /etc/blackfire/agent
 
 ;process_name=%(program_name)  ; process_name expr (default %(program_name)s)
 ;numprocs=1                    ; number of processes copies to start (def 1)


### PR DESCRIPTION
Also 
-removed root mariadb password of RESETME (on recommendation)
-fixed apc settings so that apc is available on command line,
-made blackfire php extension logging more specific.
-changed nginx log file naming convention
