### PR TITLE
lampstackplusdev better xdebug conf, pull drupal console using composer

### DIFF
--- a/lampstackplusdev/Dockerfile
+++ b/lampstackplusdev/Dockerfile
@@ -35,7 +35,7 @@ RUN composer global require drush/drush:dev-master drush/config-extra
 RUN composer global require drupal/console
 # RUN cd /app/bin && curl -LSs http://drupalconsole.com/installer | php && mv console.phar drupal
 
-# Install platform.sh cli (CONFLICTS WITH DRUPAL CONSOLE)
+# Install platform.sh cli
 RUN composer global require platformsh/cli:@stable
 # RUN composer global require "commerceguys/platform-cli=1.*"
 

--- a/lampstackplusdev/Dockerfile
+++ b/lampstackplusdev/Dockerfile
@@ -9,7 +9,10 @@ RUN /usr/bin/yum --assumeyes --verbose install openssl tar git zsh sudo vim
 # Get XDebug into the php server
 RUN /usr/bin/yum --assumeyes --verbose install php-xdebug
 
-# Set up some stuff for the app user
+# override the default php.d xdebug.ini
+ADD etc/php.d/15-xdebug.ini /etc/php.d/15-xdebug.ini 
+
+# Allow passwordless sudo for the app user
 RUN /usr/bin/echo "app        ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/app
 
 # Install nodejs and npm, which gets used for lots of stuff with SASS/SCSS
@@ -26,13 +29,13 @@ USER app
 ENV PATH /app/bin:/app/.composer/vendor/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 # Install DRUSH, which is a requiremnt for platform
-RUN composer global require drush/drush:dev-master
-RUN composer global require drush/config-extra
+RUN composer global require drush/drush:dev-master drush/config-extra
 
 # Install Drupal console
-RUN cd /app/bin && curl -LSs http://drupalconsole.com/installer | php && mv console.phar drupal
+RUN composer global require --optimize-autoloader --update-with-dependencies drupal/console
+# RUN cd /app/bin && curl -LSs http://drupalconsole.com/installer | php && mv console.phar drupal
 
-# Install platform.sh cli
+# Install platform.sh cli (CONFLICTS WITH DRUPAL CONSOLE)
 RUN composer global require platformsh/cli:@stable
 # RUN composer global require "commerceguys/platform-cli=1.*"
 
@@ -70,14 +73,3 @@ RUN /usr/sbin/usermod -s /bin/zsh app && \
 #CMD ["/bin/zsh"]
 
 ### /James Developer ---------------------------------------------------------
-### Management ---------------------------------------------------------------
-
-# This is the ending of the fullstack image, but we add it again here
-# to make it clear that this image is managed using supervisor
-
-USER root
-
-# Command that will run when the server starts
-CMD ["/usr/bin/supervisord", "--nodaemon", "--configuration", "/etc/supervisord.conf"]
-
-### /Management --------------------------------------------------------------

--- a/lampstackplusdev/Dockerfile
+++ b/lampstackplusdev/Dockerfile
@@ -32,7 +32,7 @@ ENV PATH /app/bin:/app/.composer/vendor/bin:/usr/local/sbin:/usr/local/bin:/usr/
 RUN composer global require drush/drush:dev-master drush/config-extra
 
 # Install Drupal console
-RUN composer global require --optimize-autoloader --update-with-dependencies drupal/console
+RUN composer global require drupal/console
 # RUN cd /app/bin && curl -LSs http://drupalconsole.com/installer | php && mv console.phar drupal
 
 # Install platform.sh cli (CONFLICTS WITH DRUPAL CONSOLE)

--- a/lampstackplusdev/etc/php.d/15-xdebug.ini
+++ b/lampstackplusdev/etc/php.d/15-xdebug.ini
@@ -1,0 +1,8 @@
+; Enable xdebug extension module
+zend_extension=xdebug.so
+
+xdebug.remote_enable=1
+xdebug.remote_connect_back=1
+xdebug.max_nesting_level=200
+
+; see http://xdebug.org/docs/all_settings


### PR DESCRIPTION
Added the xdebug.ini to php.d from a static file; also switched from the drupalconsole installer to the composer install.  This gave me a more functional console.
- that the drupal console bin is now called "console" and not "drupal".  Perhaps I should add a shell script that calls something like "console --drupal=/app/www --uri=${DRUPAL_URL} $@" ?
- the redundant CMD/ENTRYPOINT declarations in lampstackplusdev were removed, as they weren't really necessary.
