### PR TITLE
fixed bad fpm group spelling for lampstackplus

### DIFF
--- a/lampstackplus/etc/php-fpm.d/www.conf
+++ b/lampstackplus/etc/php-fpm.d/www.conf
@@ -29,7 +29,7 @@ listen = /var/run/php-fpm.sock
 ; Default Values: user and group are set as the running user
 ;                 mode is set to 0666
 listen.owner = nginx
-listen.group = nginx`
+listen.group = nginx
 ;listen.mode = 0666
 
 ; Unix user/group of processes


### PR DESCRIPTION
https://github.com/james-nesbitt/wunder-docker/issues/32

Fixed FPM in the lampstackplus image, by fixing the group name for socket ownership.  It had an apostrophe in the name.
