### PR TITLE
Web (nginx) user in kitematic should be added to ftp group

### DIFF
--- a/kitematic/Dockerfile
+++ b/kitematic/Dockerfile
@@ -1,7 +1,8 @@
 FROM       jamesnesbitt/wunder-lampstackplusdev
 MAINTAINER james.nesbitt@wunderkraut.com
 
-RUN usermod -a -G ftp nginx
+RUN /usr/sbin/usermod -a -G ftp nginx
+RUN /usr/sbin/usermod -a -G games nginx
 
 # Volume for the web-root
 VOLUME /app/www

--- a/kitematic/Dockerfile
+++ b/kitematic/Dockerfile
@@ -1,6 +1,8 @@
 FROM       jamesnesbitt/wunder-lampstackplusdev
 MAINTAINER james.nesbitt@wunderkraut.com
 
+RUN usermod -a -G ftp nginx
+
 # Volume for the web-root
 VOLUME /app/www
 

--- a/kitematic/Dockerfile
+++ b/kitematic/Dockerfile
@@ -1,8 +1,7 @@
 FROM       jamesnesbitt/wunder-lampstackplusdev
 MAINTAINER james.nesbitt@wunderkraut.com
 
-RUN /usr/sbin/usermod -a -G ftp nginx
-RUN /usr/sbin/usermod -a -G games nginx
+RUN /usr/sbin/usermod -a -G ftp,games nginx
 
 # Volume for the web-root
 VOLUME /app/www


### PR DESCRIPTION
that's the group that for web files when their mapped in through boot2docker (in Unison syncing situation at least).
