### PR TITLE
move OSX compliace user/group association

### DIFF
--- a/kitematic/Dockerfile
+++ b/kitematic/Dockerfile
@@ -1,8 +1,6 @@
 FROM       jamesnesbitt/wunder-lampstackplusdev
 MAINTAINER james.nesbitt@wunderkraut.com
 
-RUN /usr/sbin/usermod -a -G ftp,games nginx
-
 # Volume for the web-root
 VOLUME /app/www
 

--- a/lampstackplusdev/Dockerfile
+++ b/lampstackplusdev/Dockerfile
@@ -74,6 +74,12 @@ ADD .zshrc /app/.zshrc
 
 USER root
 
+# Add the nginx user to various groups that the user may be a part of
+#  - on OSX users are typically in the staff group, which translates into
+#  - the centos ftp group.  This is behaviour from using boot2docker
+RUN /usr/sbin/usermod -a -G ftp,games nginx
+
+# Change the default shell to zsh, and add a nice zsh prompt
 RUN /usr/sbin/usermod -s /bin/zsh app && \
     chown -R app:app /app/.zshrc /app/.oh-my-zsh
 


### PR DESCRIPTION
This patch moves some user-group asosciates from the kitematic image to the lampstack dev image
