### PR TITLE
Increase the lampstack PHP memory for cli operations to 512MB

### DIFF
--- a/lampstackplus/etc/php.ini
+++ b/lampstackplus/etc/php.ini
@@ -393,7 +393,7 @@ max_input_time = 60
 
 ; Maximum amount of memory a script may consume (128MB)
 ; http://php.net/memory-limit
-memory_limit = 128M
+memory_limit = 512M
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; Error handling and logging ;


### PR DESCRIPTION
PHP FPM should be left unaffected as it has it's own php memory limit applied, but the lower 128MB default memory usage is not enough for some comprehensive drush tasks (like running D8 tests)
