### PR TITLE
lampstack remove blackfire yum .repo file

### DIFF
--- a/lampstackplus/Dockerfile
+++ b/lampstackplus/Dockerfile
@@ -120,6 +120,9 @@ ADD etc/php.d/zz-blackfire.ini /etc/php.d/zz-blackfire.ini
 ENV BLACKFIRE_SERVER_ID %BLACKFIRE_SERVER_ID
 ENV BLACKFIRE_SERVER_TOKEN %BLACKFIRE_SERVER_TOKEN
 
+# Somnetimes the blackfire yum repo gives bigtime errors.  Remove it until upstream fixes it.
+RUN /usr/bin/rm /etc/yum.repos.d/blackfire.repo
+
 #ENTRYPOINT ["blackfire-agent"]
 #CMD ["--socket", "tcp://0.0.0.0:8707", "--config", "/dev/null"]
 #EXPOSE 8707


### PR DESCRIPTION
the repo occasionaly causes issues with yum, so this patch removes it after blackfire is installed.

See Issue https://github.com/james-nesbitt/wunder-docker/issues/40
