### PR TITLE
Fixes issue with big features downloads

### DIFF
--- a/lampstackplus/etc/php.ini
+++ b/lampstackplus/etc/php.ini
@@ -389,7 +389,7 @@ max_input_time = 60
 ;max_input_nesting_level = 64
 
 ; How many GET/POST/COOKIE input variables may be accepted
-; max_input_vars = 1000
+max_input_vars = 2000
 
 ; Maximum amount of memory a script may consume (128MB)
 ; http://php.net/memory-limit


### PR DESCRIPTION
When Drupal 7 feature will not download, but store on disk and remove a bunch of variables. Bigger max_input_vars is found to be fix it.
