### PR TITLE
rebase on centos latest instead of centos7

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM        centos:centos7
+FROM        centos
 MAINTAINER james.nesbitt@wunderkraut.com
 
 ### WUNDER BASE --------------------------------------------------------------


### PR DESCRIPTION
The old base was centos:centos7, which centos isn't even using anymore.  We might as well use latest, until we decide we need a more stable base.
