### PR TITLE
Fix new nginx user uid across all php builds

### DIFF
--- a/drupalconsole/Dockerfile
+++ b/drupalconsole/Dockerfile
@@ -30,8 +30,8 @@ RUN /usr/bin/yum --assumeyes --verbose install openssl tar git
 RUN /usr/bin/curl -sS https://getcomposer.org/installer | php -- --filename=composer --install-dir=/usr/local/bin
 
 # make sure that the nginx user is created, and has access to app user files
-# nginx:x:999:999:Nginx web server:/var/lib/nginx:/sbin/nologin
-RUN /usr/sbin/adduser --home-dir /var/lib/nginx --uid 999 --user-group --shell /bin/nologin --password "`openssl rand -base64 32 | openssl passwd -1 -stdin`" --comment "Nginx web server" nginx && \
+# nginx:x:499:499:Nginx web server:/var/lib/nginx:/sbin/nologin
+RUN /usr/sbin/adduser --home-dir /var/lib/nginx --uid 499 --user-group --shell /bin/nologin --password "`openssl rand -base64 32 | openssl passwd -1 -stdin`" --comment "Nginx web server" nginx && \
     /usr/bin/gpasswd -a nginx app
 
 # Set up some folders for the tools that we may use

--- a/drush8/Dockerfile
+++ b/drush8/Dockerfile
@@ -30,8 +30,8 @@ RUN /usr/bin/yum --assumeyes --verbose install openssl tar git
 RUN /usr/bin/yum install --assumeyes --verbose composer
 
 # make sure that the nginx user is created, and has access to app user files
-# nginx:x:999:999:Nginx web server:/var/lib/nginx:/sbin/nologin
-RUN /usr/sbin/adduser --home-dir /var/lib/nginx --uid 999 --user-group --shell /bin/nologin --password "`openssl rand -base64 32 | openssl passwd -1 -stdin`" --comment "Nginx web server" nginx && \
+# nginx:x:499:499:Nginx web server:/var/lib/nginx:/sbin/nologin
+RUN /usr/sbin/adduser --home-dir /var/lib/nginx --uid 499 --user-group --shell /bin/nologin --password "`openssl rand -base64 32 | openssl passwd -1 -stdin`" --comment "Nginx web server" nginx && \
     /usr/bin/gpasswd -a nginx app
 
 # Set up some folders for the tools that we may use

--- a/hhvm/Dockerfile
+++ b/hhvm/Dockerfile
@@ -10,8 +10,8 @@ ADD etc/yum.repos.d/no1youknowz-hhvm-repo-epel-7.repo /etc/yum.repos.d/no1youkno
 RUN /usr/bin/yum --assumeyes --verbose install hhvm
 
 # make sure that the nginx user, created, has access to app user files
-# nginx:x:999:999:Nginx web server:/var/lib/nginx:/sbin/nologin
-RUN /usr/sbin/adduser --home-dir /var/lib/nginx --uid 999 --user-group --shell /bin/nologin --password "`openssl rand -base64 32 | openssl passwd -1 -stdin`" --comment "Nginx web server" nginx && \
+# nginx:x:499:499:Nginx web server:/var/lib/nginx:/sbin/nologin
+RUN /usr/sbin/adduser --home-dir /var/lib/nginx --uid 499 --user-group --shell /bin/nologin --password "`openssl rand -base64 32 | openssl passwd -1 -stdin`" --comment "Nginx web server" nginx && \
     /usr/bin/gpasswd -a nginx app && \
     /usr/bin/mkdir -p /var/run/hhvm && \
     /usr/bin/chown nginx:app /var/run/hhvm && \

--- a/lampstackplus/Dockerfile
+++ b/lampstackplus/Dockerfile
@@ -88,7 +88,7 @@ RUN /usr/bin/yum install --assumeyes --verbose \
     php-pecl-xdebug php-pecl-zip
 
 # make sure that the nginx user, created, has access to app user files
-# nginx:x:999:999:Nginx web server:/var/lib/nginx:/sbin/nologin
+# nginx:x:499:499:Nginx web server:/var/lib/nginx:/sbin/nologin
 RUN /usr/bin/mkdir -p /app/log/php-fpm && \
     /usr/bin/chown nginx:app /app/log/php-fpm
 

--- a/php56fpm/Dockerfile
+++ b/php56fpm/Dockerfile
@@ -21,8 +21,8 @@ RUN /usr/bin/yum install -y install pygpgme blackfire-php
 RUN /usr/bin/sed -i "s,unix:///var/run/blackfire/agent.sock,tcp://blackfire.app:8707," /etc/php.d/zz-blackfire.ini
 
 # make sure that the nginx user, created, has access to app user files
-# nginx:x:999:999:Nginx web server:/var/lib/nginx:/sbin/nologin
-RUN /usr/sbin/adduser --home-dir /var/lib/nginx --uid 999 --user-group --shell /bin/nologin --password "`openssl rand -base64 32 | openssl passwd -1 -stdin`" --comment "Nginx web server" nginx && \
+# nginx:x:499:499:Nginx web server:/var/lib/nginx:/sbin/nologin
+RUN /usr/sbin/adduser --home-dir /var/lib/nginx --uid 499 --user-group --shell /bin/nologin --password "`openssl rand -base64 32 | openssl passwd -1 -stdin`" --comment "Nginx web server" nginx && \
     /usr/sbin/usermod -a -G app,ftp,games nginx && \
     /usr/bin/mkdir -p /app/log/php-fpm && \
     /usr/bin/chown nginx:app /app/log/php-fpm

--- a/php5fpm/Dockerfile
+++ b/php5fpm/Dockerfile
@@ -15,8 +15,8 @@ RUN /usr/bin/yum install -y install pygpgme blackfire-php
 RUN /usr/bin/sed -i "s,unix:///var/run/blackfire/agent.sock,tcp://blackfire.app:8707," /etc/php.d/zz-blackfire.ini
 
 # make sure that the nginx user, created, has access to app user files
-# nginx:x:999:999:Nginx web server:/var/lib/nginx:/sbin/nologin
-RUN /usr/sbin/adduser --home-dir /var/lib/nginx --uid 999 --user-group --shell /bin/nologin --password "`openssl rand -base64 32 | openssl passwd -1 -stdin`" --comment "Nginx web server" nginx && \
+# nginx:x:499:499:Nginx web server:/var/lib/nginx:/sbin/nologin
+RUN /usr/sbin/adduser --home-dir /var/lib/nginx --uid 499 --user-group --shell /bin/nologin --password "`openssl rand -base64 32 | openssl passwd -1 -stdin`" --comment "Nginx web server" nginx && \
     /usr/bin/gpasswd -a nginx app && \
     /usr/bin/mkdir -p /app/log/php-fpm && \
     /usr/bin/chown nginx:app /app/log/php-fpm

--- a/php7fpm/Dockerfile
+++ b/php7fpm/Dockerfile
@@ -21,9 +21,9 @@ ADD etc/php-fpm.conf /etc/php-fpm.conf
 ADD etc/php-fpm.d/www.conf /etc/php-fpm.d/www.conf
 
 # make sure that the nginx user, created, has access to app user files
-# nginx:x:999:999:Nginx web server:/var/lib/nginx:/sbin/nologin
-RUN /usr/sbin/adduser --home-dir /var/lib/nginx --uid 999 --user-group --shell /bin/nologin --password "`openssl rand -base64 32 | openssl passwd -1 -stdin`" --comment "Nginx web server" nginx && \
-    /usr/sbin/usermod -a -G app,ftp,games nginx
+# nginx:x:499:499:Nginx web server:/var/lib/nginx:/sbin/nologin
+RUN /usr/sbin/adduser --home-dir /var/lib/nginx --uid 499 --user-group --shell /bin/nologin --password "`openssl rand -base64 32 | openssl passwd -1 -stdin`" --comment "Nginx web server" nginx && \
+   /usr/sbin/usermod -a -G app,ftp,games nginx
 RUN /usr/bin/mkdir -p /app/log/php-fpm && \
     /usr/bin/chown nginx:app /app/log/php-fpm
 

--- a/platformsh/Dockerfile
+++ b/platformsh/Dockerfile
@@ -30,8 +30,8 @@ RUN /usr/bin/yum --assumeyes --verbose install openssl tar git
 RUN /usr/bin/yum install --assumeyes --verbose composer
 
 # make sure that the nginx user is created, and has access to app user files
-# nginx:x:999:999:Nginx web server:/var/lib/nginx:/sbin/nologin
-RUN /usr/sbin/adduser --home-dir /var/lib/nginx --uid 999 --user-group --shell /bin/nologin --password "`openssl rand -base64 32 | openssl passwd -1 -stdin`" --comment "Nginx web server" nginx && \
+# nginx:x:499:499:Nginx web server:/var/lib/nginx:/sbin/nologin
+RUN /usr/sbin/adduser --home-dir /var/lib/nginx --uid 499 --user-group --shell /bin/nologin --password "`openssl rand -base64 32 | openssl passwd -1 -stdin`" --comment "Nginx web server" nginx && \
     /usr/bin/gpasswd -a nginx app
 
 # Set up some folders for the tools that we may use


### PR DESCRIPTION
The latest centos7 nginx repo build uses UID 499 for the nginx user, instead of 999.  This patch switches all PHP builds that used a duplicate nginx user to also use 499 for UID:GID.

This fixes issues with building a number of PHP images.
