### PR TITLE
Add xdebug to the php7 image

### DIFF
--- a/php7fpm/Dockerfile
+++ b/php7fpm/Dockerfile
@@ -14,16 +14,20 @@ ADD etc/yum.repos.d/remi-php70.repo /etc/yum.repos.d/remi-php70.repo
 RUN /usr/bin/yum install --assumeyes --verbose \
     php-fpm php-opcache php-pdo php-mysql php-pgsql \
     php-ldap php-gd php-mbstring php-mcrypt php-xml \
-    php-pecl-apcu php-pecl-yaml php-pecl-uploadprogress php-pecl-zip
+    php-pecl-apcu php-pecl-yaml php-pecl-uploadprogress php-pecl-zip \
+    php-pecl-xdebug
 
 # Override some of the default php-fpm settings with our own.
 ADD etc/php-fpm.conf /etc/php-fpm.conf
 ADD etc/php-fpm.d/www.conf /etc/php-fpm.d/www.conf
 
-# Install blackfire
-ADD etc/yum.repos.d/blackfire.repo /etc/yum.repos.d/blackfire.repo
-RUN /usr/bin/yum install -y install pygpgme blackfire-php
-RUN /usr/bin/sed -i "s,unix:///var/run/blackfire/agent.sock,tcp://blackfire.app:8707," /etc/php.d/zz-blackfire.ini
+# Override some of the default php ini files
+ADD etc/php.d/15-xdebug.ini /etc/php.d/15-zxdebug.ini
+
+# Install blackfire - still doesn't work as the blackfire install script doesn't like our php7
+# ADD etc/yum.repos.d/blackfire.repo /etc/yum.repos.d/blackfire.repo
+# RUN /usr/bin/yum install -y install pygpgme blackfire-php
+# ADD etc/php.d/zz-blackfire.ini /etc/php.d/zz-blackfire.ini
 
 # make sure that the nginx user, created, has access to app user files
 # nginx:x:499:499:Nginx web server:/var/lib/nginx:/sbin/nologin

--- a/php7fpm/Dockerfile
+++ b/php7fpm/Dockerfile
@@ -20,6 +20,11 @@ RUN /usr/bin/yum install --assumeyes --verbose \
 ADD etc/php-fpm.conf /etc/php-fpm.conf
 ADD etc/php-fpm.d/www.conf /etc/php-fpm.d/www.conf
 
+# Install blackfire
+ADD etc/yum.repos.d/blackfire.repo /etc/yum.repos.d/blackfire.repo
+RUN /usr/bin/yum install -y install pygpgme blackfire-php
+RUN /usr/bin/sed -i "s,unix:///var/run/blackfire/agent.sock,tcp://blackfire.app:8707," /etc/php.d/zz-blackfire.ini
+
 # make sure that the nginx user, created, has access to app user files
 # nginx:x:499:499:Nginx web server:/var/lib/nginx:/sbin/nologin
 RUN /usr/sbin/adduser --home-dir /var/lib/nginx --uid 499 --user-group --shell /bin/nologin --password "`openssl rand -base64 32 | openssl passwd -1 -stdin`" --comment "Nginx web server" nginx && \

--- a/php7fpm/etc/php.d/15-xdebug.ini
+++ b/php7fpm/etc/php.d/15-xdebug.ini
@@ -1,0 +1,9 @@
+[xdebug]
+zend_extension=xdebug.so
+xdebug.remote_enable=true
+xdebug.remote_autostart=true
+xdebug.remote_port=9090
+;xdebug.profiler_enable=1
+xdebug.show_exception_trace=true
+xdebug.max_nesting_level=1024
+xdebug.remote_connect_back=true

--- a/php7fpm/etc/php.d/zz-blackfire.ini
+++ b/php7fpm/etc/php.d/zz-blackfire.ini
@@ -1,0 +1,9 @@
+; priority=90
+[blackfire]
+extension=blackfire.so
+blackfire.agent_socket = tcp://blackfire.app:8707
+blackfire.agent_timeout = 0.25
+;blackfire.server_id =
+;blackfire.server_token =
+;blackfire.log_level = 3
+;blackfire.log_file = /tmp/blackfire.log

--- a/php7fpm/etc/yum.repos.d/blackfire.repo
+++ b/php7fpm/etc/yum.repos.d/blackfire.repo
@@ -1,0 +1,9 @@
+[blackfire]
+name=blackfire
+baseurl=http://packages.blackfire.io/fedora/$releasever/$basearch
+repo_gpgcheck=1
+gpgcheck=0
+enabled=1
+gpgkey=https://packagecloud.io/gpg.key
+sslverify=1
+sslcacert=/etc/pki/tls/certs/ca-bundle.crt


### PR DESCRIPTION
This patch adds xdebug to the php7 image, and enables it with the same settings used in the php56 image.

This PR relates to issue: https://github.com/james-nesbitt/wunder-docker/issues/77

Some blackfire related changes were also added, but none that affect the image, as the blackfire installer doesn't recognize our remi php.  When the blackfire install works, we can just uncomment the dockerfile code and enable it.
